### PR TITLE
Update

### DIFF
--- a/Contrat/CRUDonFacture.py
+++ b/Contrat/CRUDonFacture.py
@@ -164,3 +164,10 @@ async def obtenir_axe_contrat(pool, contrat_id: int) -> str | None:
     finally:
         if conn:
             pool.release(conn)
+
+
+"""
+    Répartition de la facturation :
+    - Une facture pour chaque traitement en géneral
+    - Possibilité d'assigner une seule facture pour deux ou plusieurs traitements
+"""

--- a/Contrat/CRUDonPlanning.py
+++ b/Contrat/CRUDonPlanning.py
@@ -191,3 +191,14 @@ async def delete_planning(pool, planning_id: int) -> int:
     finally:
         if conn:
             pool.release(conn)
+
+"""
+    Répartition des redondances pour les plannings :
+    - Par semaine
+    - Deux à trois fois par semaine (Toutes les semaines)
+    - Deux fois par mois (Tous les 15 jours)
+    - Par mois
+    - Tous les deux mois
+    - Tous les 4 mois
+    - Tous les 6 mois 
+"""

--- a/Contrat/mainCRUDonPlanificator.py
+++ b/Contrat/mainCRUDonPlanificator.py
@@ -342,9 +342,6 @@ async def main():
                                 continue
                             mois = int(mois_str)
                             annee = int(annee_str)
-                            # Cette partie du code dépend d'un module externe, je l'ai donc commentée.
-                            # Pour la faire fonctionner, vous devez vous assurer que le module 'Rapports.export_excel'
-                            # est correctement installé et que la fonction 'generationFactureClient' est bien définie.
                             print("La fonction de génération de rapport Excel n'est pas implémentée dans ce script.")
                         except ValueError:
                             print("Entrée invalide. Veuillez entrer des numéros valides.")

--- a/scriptSQL/Planificator.sql
+++ b/scriptSQL/Planificator.sql
@@ -143,7 +143,7 @@ CREATE TABLE Client (
                         nom VARCHAR(255) NOT NULL,
                         prenom VARCHAR(255),
                         email VARCHAR(255) NOT NULL,
-                        telephone VARCHAR(20) NOT NULL,
+                        telephone VARCHAR(30) NOT NULL,
                         adresse VARCHAR(255) NOT NULL,
                         nif VARCHAR(50),
                         stat VARCHAR(50),
@@ -293,5 +293,5 @@ CREATE TABLE Historique (
 
 /*
     Historique regroupe toutes les informations utiles pour chaque traitement effectué
-    Modifié et corrigé le 18 Juillet 2025
+    Modifié et corrigé le 18 Septembre 2025
 */


### PR DESCRIPTION
This pull request contains several small updates across the codebase and database schema, primarily focused on documentation improvements and minor schema adjustments. The most notable changes include clarifications in billing and planning logic within docstrings, a schema modification to allow longer phone numbers, and a correction to a comment date.

**Documentation improvements:**

* Added explanatory docstrings to clarify the logic for billing allocation in `obtenir_axe_contrat` (`Contrat/CRUDonFacture.py`) and planning recurrence options in `delete_planning` (`Contrat/CRUDonPlanning.py`). [[1]](diffhunk://#diff-918203db139798f329d826e4995335a1e59c8eebf931eda6b4ea162828f9db1bR167-R173) [[2]](diffhunk://#diff-bb67816d803593f8628c6196815c5fc262453be30e88e1a2de05c869d14a9814R194-R204)

**Database schema update:**

* Increased the allowed length of the `telephone` field in the `Client` table from 20 to 30 characters in `Planificator.sql`.

**Comment and documentation corrections:**

* Updated the modification date in the comment for the `Historique` table to September 2025 in `Planificator.sql`.
* Removed outdated comments related to an unimplemented Excel report generation feature in `mainCRUDonPlanificator.py`.